### PR TITLE
Allow Dusk to run in production

### DIFF
--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -39,10 +39,6 @@ class DuskServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        if ($this->app->environment('production')) {
-            throw new Exception('It is unsafe to run Dusk in production.');
-        }
-
         if ($this->app->runningInConsole()) {
             $this->commands([
                 Console\InstallCommand::class,


### PR DESCRIPTION
Is for a reason. Using Console Dusk and not possible to run it on a production server otherwise (whole server is firewalled)